### PR TITLE
introduce testing matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: pytest
-        run: uv run --with 'pydantic-ai-slim==${{ matrix.pydantic-ai-version }}' --with 'apache-airflow==${{ matrix.airflow-version }}' pytest -v
+        run: uv run --with 'pydantic-ai-slim==${{ matrix.pydantic-ai-version }}' --with 'apache-airflow==${{ matrix.airflow-version }}' --with 'distutils' pytest -v
 
       - name: minimize uv cache
         run: uv cache prune --ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
         run: uv pip install setuptools
 
       - name: pytest
-        run: uv run --with 'setuptools' --with 'pydantic-ai-slim==${{ matrix.pydantic-ai-version }}' --with 'apache-airflow==${{ matrix.airflow-version }}' pytest -v
+        run: uv run --with 'setuptools pydantic-ai-slim==${{ matrix.pydantic-ai-version }} apache-airflow==${{ matrix.airflow-version }}' pytest -v
 
       - name: minimize uv cache
         run: uv cache prune --ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,16 +44,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-        pydantic-ai-version:
-          # cherry pick a couple examples with big changes, only care about >= 0.0.40
-          - "0.0.40"
-          - "0.0.44"
-          - "0.0.49"
-        airflow-version:
-          # only care about >= 2.8
-          - "2.8"
-          - "2.9"
-          - "2.10"
 
     steps:
       - uses: actions/checkout@v4
@@ -66,12 +56,6 @@ jobs:
 
       - name: install python
         run: uv python install ${{ matrix.python-version }}
-
-      - name: install setuptools
-        run: sudo apt install -y python3-setuptools
-
-      - name: install pydantic-ai-slim and airflow
-        run: uv add pydantic-ai-slim==${{ matrix.pydantic-ai-version }} apache-airflow==${{ matrix.airflow-version }}
 
       - name: install dependencies
         run: uv sync --all-extras --dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,24 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+        pydantic-ai-version:
+          # cherry pick a couple examples with big changes, only care about >= 0.0.40
+          - "0.0.40"
+          - "0.0.44"
+          - "0.0.49"
+        airflow-version:
+          # only care about >= 2.8
+          - "2.8"
+          - "2.9"
+          - "2.10"
+
     steps:
       - uses: actions/checkout@v4
 
@@ -47,7 +65,10 @@ jobs:
           enable-cache: true
 
       - name: install python
-        run: uv python install
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: install specific pydantic-ai and airflow versions
+        run: uv pip install pydantic-ai-slim==${{ matrix.pydantic-ai-version }} apache-airflow==${{ matrix.airflow-version }}
 
       - name: install dependencies
         run: uv sync --all-extras --dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,14 +67,14 @@ jobs:
       - name: install python
         run: uv python install ${{ matrix.python-version }}
 
+      - name: install pydantic-ai-slim and airflow
+        run: uv add pydantic-ai-slim==${{ matrix.pydantic-ai-version }} apache-airflow==${{ matrix.airflow-version }}
+
       - name: install dependencies
         run: uv sync --all-extras --dev
 
       - name: install setuptools
         run: uv add setuptools
-
-      - name: install pydantic-ai-slim and airflow
-        run: uv add pydantic-ai-slim==${{ matrix.pydantic-ai-version }} apache-airflow==${{ matrix.airflow-version }}
 
       - name: pytest
         run: uv run pytest -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,10 +40,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: pytest
-        run: uv run --with 'pydantic-ai-slim==${{ matrix.pydantic-ai-version }}' --with 'apache-airflow==${{ matrix.airflow-version }}' --with 'distutils' pytest -v
+        run: uv run --with 'pydantic-ai-slim==${{ matrix.pydantic-ai-version }}' --with 'apache-airflow==${{ matrix.airflow-version }}' --with 'setuptools' pytest -v
 
       - name: minimize uv cache
         run: uv cache prune --ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,14 +67,11 @@ jobs:
       - name: install python
         run: uv python install ${{ matrix.python-version }}
 
-      - name: install specific pydantic-ai and airflow versions
-        run: uv pip install pydantic-ai-slim==${{ matrix.pydantic-ai-version }} apache-airflow==${{ matrix.airflow-version }}
-
       - name: install dependencies
         run: uv sync --all-extras --dev
 
       - name: pytest
-        run: uv run pytest -v
+        run: uv run --with 'pydantic-ai-slim==${{ matrix.pydantic-ai-version }}' --with 'apache-airflow==${{ matrix.airflow-version }}' pytest -v
 
       - name: minimize uv cache
         run: uv cache prune --ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,11 +70,11 @@ jobs:
       - name: install dependencies
         run: uv sync --all-extras --dev
 
-      - name: install setuptools
-        run: uv pip install setuptools
+      - name: install pydantic-ai-slim and airflow
+        run: uv add pydantic-ai-slim==${{ matrix.pydantic-ai-version }} apache-airflow==${{ matrix.airflow-version }}
 
       - name: pytest
-        run: uv run --with 'setuptools pydantic-ai-slim==${{ matrix.pydantic-ai-version }} apache-airflow==${{ matrix.airflow-version }}' pytest -v
+        run: uv run pytest -v
 
       - name: minimize uv cache
         run: uv cache prune --ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,8 +70,11 @@ jobs:
       - name: install dependencies
         run: uv sync --all-extras --dev
 
+      - name: install setuptools
+        run: uv pip install setuptools
+
       - name: pytest
-        run: uv run --with 'pydantic-ai-slim==${{ matrix.pydantic-ai-version }}' --with 'apache-airflow==${{ matrix.airflow-version }}' --with 'setuptools' pytest -v
+        run: uv run --with 'setuptools' --with 'pydantic-ai-slim==${{ matrix.pydantic-ai-version }}' --with 'apache-airflow==${{ matrix.airflow-version }}' pytest -v
 
       - name: minimize uv cache
         run: uv cache prune --ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: pytest
-        run: uv run pytest -v
+        run: uv run --python ${{ matrix.python-version }} pytest -v
 
       - name: minimize uv cache
         run: uv cache prune --ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: install setuptools
-        run: uv pip install setuptools --system
+        run: apt install -y python3-setuptools
 
       - name: install pydantic-ai-slim and airflow
         run: uv add pydantic-ai-slim==${{ matrix.pydantic-ai-version }} apache-airflow==${{ matrix.airflow-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,14 +67,14 @@ jobs:
       - name: install python
         run: uv python install ${{ matrix.python-version }}
 
+      - name: install setuptools
+        run: uv pip install setuptools --system
+
       - name: install pydantic-ai-slim and airflow
         run: uv add pydantic-ai-slim==${{ matrix.pydantic-ai-version }} apache-airflow==${{ matrix.airflow-version }}
 
       - name: install dependencies
         run: uv sync --all-extras --dev
-
-      - name: install setuptools
-        run: uv add setuptools
 
       - name: pytest
         run: uv run pytest -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: install setuptools
-        run: apt install -y python3-setuptools
+        run: sudo apt install -y python3-setuptools
 
       - name: install pydantic-ai-slim and airflow
         run: uv add pydantic-ai-slim==${{ matrix.pydantic-ai-version }} apache-airflow==${{ matrix.airflow-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,9 @@ jobs:
       - name: install dependencies
         run: uv sync --all-extras --dev
 
+      - name: install setuptools
+        run: uv add setuptools
+
       - name: install pydantic-ai-slim and airflow
         run: uv add pydantic-ai-slim==${{ matrix.pydantic-ai-version }} apache-airflow==${{ matrix.airflow-version }}
 

--- a/airflow_ai_sdk/models/tool.py
+++ b/airflow_ai_sdk/models/tool.py
@@ -2,8 +2,6 @@
 Module that contains the AirflowTool class.
 """
 
-from typing import Union
-
 from pydantic_ai import Tool as PydanticTool
 from pydantic_ai.tools import AgentDepsT, _messages
 

--- a/airflow_ai_sdk/models/tool.py
+++ b/airflow_ai_sdk/models/tool.py
@@ -19,7 +19,7 @@ class WrappedTool(PydanticTool[AgentDepsT]):
         message: _messages.ToolCallPart,
         *args: object,
         **kwargs: object,
-    ) -> Union[_messages.ToolReturnPart, _messages.RetryPromptPart]:
+    ) -> _messages.ToolReturnPart | _messages.RetryPromptPart:
         from pprint import pprint
 
         print(f"::group::Calling tool {message.tool_name} with args {message.args}")

--- a/airflow_ai_sdk/models/tool.py
+++ b/airflow_ai_sdk/models/tool.py
@@ -2,6 +2,8 @@
 Module that contains the AirflowTool class.
 """
 
+from typing import Union
+
 from pydantic_ai import Tool as PydanticTool
 from pydantic_ai.tools import AgentDepsT, _messages
 
@@ -17,7 +19,7 @@ class WrappedTool(PydanticTool[AgentDepsT]):
         message: _messages.ToolCallPart,
         *args: object,
         **kwargs: object,
-    ) -> _messages.ToolReturnPart | _messages.RetryPromptPart:
+    ) -> Union[_messages.ToolReturnPart, _messages.RetryPromptPart]:
         from pprint import pprint
 
         print(f"::group::Calling tool {message.tool_name} with args {message.args}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,10 @@ select = [
     "W293", # Avoid blank lines with whitespace
 ]
 
+ignore = [
+    "UP007" # Don't change types from `Union[..., ...]` to `... | ...` because we support 3.9
+]
+
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true      # Don't require `-> None` on __init__ (MyPy treats __init__ as implicitly returning None)
 ignore-fully-untyped = false # Even fully untyped functions are reported (ensure *every* function has type hints)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "airflow-ai-sdk"
 dynamic = ["version"]
 description = "SDK for building LLM workflows and agents using Apache Airflow"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.7.0",
     "typing-extensions>=4.0.0",
@@ -68,10 +68,6 @@ select = [
     "I",    # Import order (isort) – ensure imports are sorted into groups (stdlib, third-party, local) for readability
     "UP",   # Python upgrades (pyupgrade) – suggest modern syntax (f-strings, walrus operator, etc.) for clean, up-to-date code
     "W293", # Avoid blank lines with whitespace
-]
-
-ignore = [
-    "UP007" # Don't change types from `Union[..., ...]` to `... | ...` because we support 3.9
 ]
 
 [tool.ruff.lint.flake8-annotations]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ line-length = 88
 indent-width = 4
 exclude = ["tests", "examples"]
 
-target-version = "py313"
+target-version = "py312"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
this tests against python 3.10, 3.11, 3.12 and drops support for python 3.9 because the way we write type hints isn't supported in 3.9

we can consider adding back 3.9 support if people need it