### PR TITLE
Improve docstrings with examples

### DIFF
--- a/airflow_ai_sdk/decorators/agent.py
+++ b/airflow_ai_sdk/decorators/agent.py
@@ -14,8 +14,19 @@ if TYPE_CHECKING:
 
 
 def agent(agent: Agent, **kwargs: dict[str, Any]) -> "TaskDecorator":
-    """
-    Decorator to make agent calls.
+    """Decorator to execute an :class:`pydantic_ai.Agent` inside an Airflow task.
+
+    Example:
+        >>> from airflow.decorators import task
+        >>> from pydantic_ai import Agent
+        >>> import airflow_ai_sdk as ai_sdk
+
+        >>> my_agent = Agent(model="o3-mini", system_prompt="Say hello")
+
+        >>> @task
+        ... @ai_sdk.agent(my_agent)
+        ... def greet(name: str) -> str:
+        ...     return name
     """
     kwargs["agent"] = agent
     return task_decorator_factory(

--- a/airflow_ai_sdk/decorators/branch.py
+++ b/airflow_ai_sdk/decorators/branch.py
@@ -19,8 +19,13 @@ def llm_branch(
     allow_multiple_branches: bool = False,
     **kwargs: dict[str, Any],
 ) -> "TaskDecorator":
-    """
-    Decorator to make LLM calls and branch the execution of a DAG based on the result.
+    """Decorator to branch a DAG based on the result of an LLM call.
+
+    Example:
+        >>> import airflow_ai_sdk as ai_sdk
+        >>> @ai_sdk.llm_branch(model="o3-mini", system_prompt="Return 'a' or 'b'")
+        ... def decide() -> str:
+        ...     return "Which path?"
     """
     kwargs["model"] = model
     kwargs["system_prompt"] = system_prompt

--- a/airflow_ai_sdk/decorators/embed.py
+++ b/airflow_ai_sdk/decorators/embed.py
@@ -15,12 +15,22 @@ def embed(
     model_name: str = "all-MiniLM-L12-v2",
     **kwargs: dict[str, Any],
 ) -> "TaskDecorator":
-    """
-    Decorator to embed text using a SentenceTransformer model.
+    """Decorator to embed text using a SentenceTransformer model.
 
     Args:
-        model_name: The name of the model to use for the embedding. Passed to the `SentenceTransformer` constructor.
-        **kwargs: Keyword arguments to pass to the `EmbedDecoratedOperator` constructor.
+        model_name: The name of the model to use for the embedding. Passed to
+            the ``SentenceTransformer`` constructor.
+        **kwargs: Keyword arguments to pass to the ``EmbedDecoratedOperator``
+            constructor.
+
+    Example:
+        >>> from airflow.decorators import task
+        >>> import airflow_ai_sdk as ai_sdk
+
+        >>> @task
+        ... @ai_sdk.embed()
+        ... def vectorize() -> str:
+        ...     return "Example text"
     """
     kwargs["model_name"] = model_name
     return task_decorator_factory(

--- a/airflow_ai_sdk/decorators/llm.py
+++ b/airflow_ai_sdk/decorators/llm.py
@@ -20,8 +20,13 @@ def llm(
     result_type: type[BaseModel] | None = None,
     **kwargs: dict[str, Any],
 ) -> "TaskDecorator":
-    """
-    Decorator to make LLM calls.
+    """Decorator to make a single call to an LLM.
+
+    Example:
+        >>> import airflow_ai_sdk as ai_sdk
+        >>> @ai_sdk.llm(model="o3-mini", system_prompt="Translate to French")
+        ... def translate(text: str) -> str:
+        ...     return text
     """
     kwargs["model"] = model
     kwargs["result_type"] = result_type

--- a/airflow_ai_sdk/operators/agent.py
+++ b/airflow_ai_sdk/operators/agent.py
@@ -12,8 +12,22 @@ from airflow_ai_sdk.models.tool import WrappedTool
 
 
 class AgentDecoratedOperator(_PythonDecoratedOperator):
-    """
-    Operator that executes an agent. You can supply a Python callable that returns a string or a list of strings.
+    """Operator that executes a :class:`pydantic_ai.Agent`.
+
+    Example:
+        >>> from pydantic_ai import Agent
+        >>> from airflow_ai_sdk.operators.agent import AgentDecoratedOperator
+
+        >>> def prompt() -> str:
+        ...     return "Hello"
+
+        >>> operator = AgentDecoratedOperator(
+        ...     task_id="example",
+        ...     python_callable=prompt,
+        ...     agent=Agent(model="o3-mini", system_prompt="Say hello"),
+        ...     op_args=[],
+        ...     op_kwargs={},
+        ... )
     """
 
     custom_operator_name = "@task.agent"

--- a/airflow_ai_sdk/operators/embed.py
+++ b/airflow_ai_sdk/operators/embed.py
@@ -8,8 +8,21 @@ from airflow_ai_sdk.airflow import Context, _PythonDecoratedOperator
 
 
 class EmbedDecoratedOperator(_PythonDecoratedOperator):
-    """
-    Operator that builds embeddings for some text.
+    """Operator that builds embeddings for text.
+
+    Example:
+        >>> from airflow_ai_sdk.operators.embed import EmbedDecoratedOperator
+
+        >>> def produce_text() -> str:
+        ...     return "document"
+
+        >>> operator = EmbedDecoratedOperator(
+        ...     task_id="embed",
+        ...     python_callable=produce_text,
+        ...     op_args=[],
+        ...     op_kwargs={},
+        ...     model_name="all-MiniLM-L12-v2",
+        ... )
     """
 
     custom_operator_name = "@task.embed"

--- a/airflow_ai_sdk/operators/llm.py
+++ b/airflow_ai_sdk/operators/llm.py
@@ -11,9 +11,20 @@ from airflow_ai_sdk.operators.agent import AgentDecoratedOperator
 
 
 class LLMDecoratedOperator(AgentDecoratedOperator):
-    """
-    Provides an abstraction on top of the Agent class. Not as powerful as the Agent class, but
-    provides a simpler interface.
+    """Simpler interface for performing a single LLM call.
+
+    Example:
+        >>> from airflow_ai_sdk.operators.llm import LLMDecoratedOperator
+
+        >>> def make_prompt() -> str:
+        ...     return "Hello"
+
+        >>> operator = LLMDecoratedOperator(
+        ...     task_id="llm",
+        ...     python_callable=make_prompt,
+        ...     model="o3-mini",
+        ...     system_prompt="Reply politely",
+        ... )
     """
 
     custom_operator_name = "@task.llm"

--- a/airflow_ai_sdk/operators/llm_branch.py
+++ b/airflow_ai_sdk/operators/llm_branch.py
@@ -12,8 +12,20 @@ from airflow_ai_sdk.operators.agent import AgentDecoratedOperator
 
 
 class LLMBranchDecoratedOperator(AgentDecoratedOperator, BranchMixIn):
-    """
-    A decorator that branches the execution of a DAG based on the result of an LLM call.
+    """Branch a DAG based on the result of an LLM call.
+
+    Example:
+        >>> from airflow_ai_sdk.operators.llm_branch import LLMBranchDecoratedOperator
+
+        >>> def make_prompt() -> str:
+        ...     return "Choose"
+
+        >>> operator = LLMBranchDecoratedOperator(
+        ...     task_id="branch",
+        ...     python_callable=make_prompt,
+        ...     model="o3-mini",
+        ...     system_prompt="Return 'a' or 'b'",
+        ... )
     """
 
     custom_operator_name = "@task.llm_branch"

--- a/docs/interface/airflow_ai_sdk_decorators_agent.md
+++ b/docs/interface/airflow_ai_sdk_decorators_agent.md
@@ -4,5 +4,17 @@ This module contains the decorators for the agent.
 
 ## agent
 
-Decorator to make agent calls.
+Decorator to execute an :class:`pydantic_ai.Agent` inside an Airflow task.
+
+Example:
+    >>> from airflow.decorators import task
+    >>> from pydantic_ai import Agent
+    >>> import airflow_ai_sdk as ai_sdk
+
+    >>> my_agent = Agent(model="o3-mini", system_prompt="Say hello")
+
+    >>> @task
+    ... @ai_sdk.agent(my_agent)
+    ... def greet(name: str) -> str:
+    ...     return name
 

--- a/docs/interface/airflow_ai_sdk_decorators_branch.md
+++ b/docs/interface/airflow_ai_sdk_decorators_branch.md
@@ -4,5 +4,11 @@ This module contains the decorators for the llm_branch decorator.
 
 ## llm_branch
 
-Decorator to make LLM calls and branch the execution of a DAG based on the result.
+Decorator to branch a DAG based on the result of an LLM call.
+
+Example:
+    >>> import airflow_ai_sdk as ai_sdk
+    >>> @ai_sdk.llm_branch(model="o3-mini", system_prompt="Return 'a' or 'b'")
+    ... def decide() -> str:
+    ...     return "Which path?"
 

--- a/docs/interface/airflow_ai_sdk_decorators_embed.md
+++ b/docs/interface/airflow_ai_sdk_decorators_embed.md
@@ -7,6 +7,17 @@ This module contains the decorators for embedding.
 Decorator to embed text using a SentenceTransformer model.
 
 Args:
-    model_name: The name of the model to use for the embedding. Passed to the `SentenceTransformer` constructor.
-    **kwargs: Keyword arguments to pass to the `EmbedDecoratedOperator` constructor.
+    model_name: The name of the model to use for the embedding. Passed to
+        the ``SentenceTransformer`` constructor.
+    **kwargs: Keyword arguments to pass to the ``EmbedDecoratedOperator``
+        constructor.
+
+Example:
+    >>> from airflow.decorators import task
+    >>> import airflow_ai_sdk as ai_sdk
+
+    >>> @task
+    ... @ai_sdk.embed()
+    ... def vectorize() -> str:
+    ...     return "Example text"
 

--- a/docs/interface/airflow_ai_sdk_decorators_llm.md
+++ b/docs/interface/airflow_ai_sdk_decorators_llm.md
@@ -4,5 +4,11 @@ This module contains the decorators for the llm decorator.
 
 ## llm
 
-Decorator to make LLM calls.
+Decorator to make a single call to an LLM.
+
+Example:
+    >>> import airflow_ai_sdk as ai_sdk
+    >>> @ai_sdk.llm(model="o3-mini", system_prompt="Translate to French")
+    ... def translate(text: str) -> str:
+    ...     return text
 

--- a/docs/interface/airflow_ai_sdk_operators_agent.md
+++ b/docs/interface/airflow_ai_sdk_operators_agent.md
@@ -4,5 +4,20 @@ Module that contains the AgentOperator class.
 
 ## AgentDecoratedOperator
 
-Operator that executes an agent. You can supply a Python callable that returns a string or a list of strings.
+Operator that executes a :class:`pydantic_ai.Agent`.
+
+Example:
+    >>> from pydantic_ai import Agent
+    >>> from airflow_ai_sdk.operators.agent import AgentDecoratedOperator
+
+    >>> def prompt() -> str:
+    ...     return "Hello"
+
+    >>> operator = AgentDecoratedOperator(
+    ...     task_id="example",
+    ...     python_callable=prompt,
+    ...     agent=Agent(model="o3-mini", system_prompt="Say hello"),
+    ...     op_args=[],
+    ...     op_kwargs={},
+    ... )
 

--- a/docs/interface/airflow_ai_sdk_operators_embed.md
+++ b/docs/interface/airflow_ai_sdk_operators_embed.md
@@ -4,5 +4,19 @@ Module that contains the EmbedOperator class.
 
 ## EmbedDecoratedOperator
 
-Operator that builds embeddings for some text.
+Operator that builds embeddings for text.
+
+Example:
+    >>> from airflow_ai_sdk.operators.embed import EmbedDecoratedOperator
+
+    >>> def produce_text() -> str:
+    ...     return "document"
+
+    >>> operator = EmbedDecoratedOperator(
+    ...     task_id="embed",
+    ...     python_callable=produce_text,
+    ...     op_args=[],
+    ...     op_kwargs={},
+    ...     model_name="all-MiniLM-L12-v2",
+    ... )
 

--- a/docs/interface/airflow_ai_sdk_operators_llm.md
+++ b/docs/interface/airflow_ai_sdk_operators_llm.md
@@ -4,6 +4,18 @@ Module that contains the AgentOperator class.
 
 ## LLMDecoratedOperator
 
-Provides an abstraction on top of the Agent class. Not as powerful as the Agent class, but
-provides a simpler interface.
+Simpler interface for performing a single LLM call.
+
+Example:
+    >>> from airflow_ai_sdk.operators.llm import LLMDecoratedOperator
+
+    >>> def make_prompt() -> str:
+    ...     return "Hello"
+
+    >>> operator = LLMDecoratedOperator(
+    ...     task_id="llm",
+    ...     python_callable=make_prompt,
+    ...     model="o3-mini",
+    ...     system_prompt="Reply politely",
+    ... )
 

--- a/docs/interface/airflow_ai_sdk_operators_llm_branch.md
+++ b/docs/interface/airflow_ai_sdk_operators_llm_branch.md
@@ -4,5 +4,18 @@ Module that contains the AgentOperator class.
 
 ## LLMBranchDecoratedOperator
 
-A decorator that branches the execution of a DAG based on the result of an LLM call.
+Branch a DAG based on the result of an LLM call.
+
+Example:
+    >>> from airflow_ai_sdk.operators.llm_branch import LLMBranchDecoratedOperator
+
+    >>> def make_prompt() -> str:
+    ...     return "Choose"
+
+    >>> operator = LLMBranchDecoratedOperator(
+    ...     task_id="branch",
+    ...     python_callable=make_prompt,
+    ...     model="o3-mini",
+    ...     system_prompt="Return 'a' or 'b'",
+    ... )
 


### PR DESCRIPTION
## Summary
- document how to use decorators with examples
- autogenerate docs with new docstrings

## Testing
- `uv run ruff format --check .`
- `uv run ruff check --output-format=github .`
- `uv run pytest -v`
