### PR TITLE
Switch to output_type while still supporting result_type in pydantic-ai 0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,7 +165,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Ruff stuff:
 .ruff_cache/

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ from airflow.models.dagrun import DagRun
 
 @task.llm(
     model="gpt-4o-mini",
-    result_type=Literal["positive", "negative", "neutral"],
+    output_type=Literal["positive", "negative", "neutral"],
     system_prompt="Classify the sentiment of the given text.",
 )
 def process_with_llm(dag_run: DagRun) -> str:

--- a/airflow_ai_sdk/decorators/llm.py
+++ b/airflow_ai_sdk/decorators/llm.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 def llm(
     model: models.Model | models.KnownModelName,
     system_prompt: str,
-    result_type: type[BaseModel] | None = None,
+    output_type: type[BaseModel] | None = None,
     **kwargs: dict[str, Any],
 ) -> "TaskDecorator":
     """
@@ -32,7 +32,7 @@ def llm(
     ```
     """
     kwargs["model"] = model
-    kwargs["result_type"] = result_type
+    kwargs["output_type"] = output_type
     kwargs["system_prompt"] = system_prompt
     return task_decorator_factory(
         decorated_operator_class=LLMDecoratedOperator,

--- a/airflow_ai_sdk/decorators/llm.py
+++ b/airflow_ai_sdk/decorators/llm.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 def llm(
     model: models.Model | models.KnownModelName,
     system_prompt: str,
-    output_type: type[BaseModel] | None = None,
     **kwargs: dict[str, Any],
 ) -> "TaskDecorator":
     """
@@ -32,7 +31,6 @@ def llm(
     ```
     """
     kwargs["model"] = model
-    kwargs["output_type"] = output_type
     kwargs["system_prompt"] = system_prompt
     return task_decorator_factory(
         decorated_operator_class=LLMDecoratedOperator,

--- a/airflow_ai_sdk/operators/llm.py
+++ b/airflow_ai_sdk/operators/llm.py
@@ -46,8 +46,10 @@ class LLMDecoratedOperator(AgentDecoratedOperator):
         self,
         model: models.Model | models.KnownModelName,
         system_prompt: str,
-        output_type: type[BaseModel] | None = _sentinel,  # TODO change to type[BaseModel] = str in 1.0.0
-        result_type: type[BaseModel] | None = _sentinel,  # Deprecated. Will be removed in 1.0.0
+        # TODO change to type[BaseModel] = str in 1.0.0
+        output_type: type[BaseModel] | None = _sentinel,
+        # Deprecated. Will be removed in 1.0.0
+        result_type: type[BaseModel] | None = _sentinel,
         **kwargs: dict[str, Any],
     ):
         """
@@ -82,7 +84,9 @@ class LLMDecoratedOperator(AgentDecoratedOperator):
             output_type = result_type
         else:
             # User configured both output_type and result_type, raise error
-            raise ValueError("Provide only one of `output_type` (preferred) or `result_type` (deprecated), not both.")
+            raise ValueError(
+                "Provide only one of `output_type` (preferred) or `result_type` (deprecated), not both."
+            )
 
         agent = Agent(
             model=model,

--- a/airflow_ai_sdk/operators/llm.py
+++ b/airflow_ai_sdk/operators/llm.py
@@ -64,9 +64,9 @@ class LLMDecoratedOperator(AgentDecoratedOperator):
 
         # In pydantic-ai==0.6.0, result_type was replaced by output_type. In airflow-ai-sdk, to avoid breaking
         # changes, we'd like to support result_type until airflow-ai-sdk==1.0.0.
-        # We have to do type ping-ponging here to continue supporting result_type with default value str until
-        # 1.0.0. The intended behaviour is that output_type and result_type are optional and default to str.
-        # To distinguish between a default and user-supplied value, we have to use a sentinel.
+        # Because we want to raise a DeprecationWarning in case the user configures result_type, the arguments
+        # default to a sentinel value, which enables us to distinguish between user-supplied values and
+        # default values. This can be removed once we release airflow-ai-sdk==1.0.0.
         if output_type is self._sentinel and result_type is self._sentinel:
             # User didn't configure either, default to str
             output_type = str

--- a/airflow_ai_sdk/operators/llm.py
+++ b/airflow_ai_sdk/operators/llm.py
@@ -3,6 +3,7 @@ This module provides the LLMDecoratedOperator class for making single LLM calls
 within Airflow tasks.
 """
 
+import warnings
 from typing import Any
 
 from pydantic import BaseModel
@@ -38,11 +39,15 @@ class LLMDecoratedOperator(AgentDecoratedOperator):
 
     custom_operator_name = "@task.llm"
 
+    # Used for distinguishing user-provided values vs default value
+    _sentinel = object()
+
     def __init__(
         self,
         model: models.Model | models.KnownModelName,
         system_prompt: str,
-        result_type: type[BaseModel] = str,
+        output_type: type[BaseModel] | None = _sentinel,  # TODO change to type[BaseModel] = str in 1.0.0
+        result_type: type[BaseModel] | None = _sentinel,  # Deprecated. Will be removed in 1.0.0
         **kwargs: dict[str, Any],
     ):
         """
@@ -51,12 +56,37 @@ class LLMDecoratedOperator(AgentDecoratedOperator):
         Args:
             model: The LLM model to use for the call.
             system_prompt: The system prompt to use for the call.
-            result_type: Optional Pydantic model type to validate and parse the result.
+            output_type: Optional Pydantic model type to validate and parse the result.
             **kwargs: Additional keyword arguments for the operator.
         """
+
+        # In pydantic-ai==0.6.0, result_type was replaced by output_type. In airflow-ai-sdk, to avoid breaking
+        # changes, we'd like to support result_type until airflow-ai-sdk==1.0.0.
+        # We have to do type ping-ponging here to continue supporting result_type with default value str until
+        # 1.0.0. The intended behaviour is that output_type and result_type are optional and default to str.
+        # To distinguish between a default and user-supplied value, we have to use a sentinel.
+        if output_type is self._sentinel and result_type is self._sentinel:
+            # User didn't configure either, default to str
+            output_type = str
+        elif output_type is not self._sentinel and result_type is self._sentinel:
+            # User configured output_type, leave as-is
+            pass
+        elif output_type is self._sentinel and result_type is not self._sentinel:
+            # User configured result_type, raise DeprecationWarning and map to output_type
+            warnings.warn(
+                "Argument `result_type` is deprecated and will be removed in version 1.0.0. "
+                "Use `output_type` instead.",
+                category=DeprecationWarning,
+                stacklevel=2,  # Points to the user code
+            )
+            output_type = result_type
+        else:
+            # User configured both output_type and result_type, raise error
+            raise ValueError("Provide only one of `output_type` (preferred) or `result_type` (deprecated), not both.")
+
         agent = Agent(
             model=model,
             system_prompt=system_prompt,
-            result_type=result_type,
+            output_type=output_type,
         )
         super().__init__(agent=agent, **kwargs)

--- a/airflow_ai_sdk/operators/llm_branch.py
+++ b/airflow_ai_sdk/operators/llm_branch.py
@@ -85,7 +85,7 @@ class LLMBranchDecoratedOperator(AgentDecoratedOperator, BranchMixIn):
         self.agent = Agent(
             model=self.model,
             system_prompt=self.system_prompt,
-            result_type=downstream_tasks_enum,
+            output_type=downstream_tasks_enum,
         )
 
         result = super().execute(context)

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -25,7 +25,7 @@ Shows how to use `@task.llm` with Pydantic models to parse structured data from 
 **Features demonstrated:**
 - Creating a custom Pydantic model for structured LLM output
 - PII masking in preprocessing
-- Using `result_type` parameter with a Pydantic model
+- Using `output_type` parameter with a Pydantic model
 - Task mapping with `expand()` to process multiple feedback items
 - Conditional execution with `AirflowSkipException`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,7 +21,7 @@ import airflow_ai_sdk as ai_sdk
 
 @task.llm(
     model="gpt-4o-mini",  # model name
-    result_type=str,       # return type
+    output_type=str,       # return type
     system_prompt="You are a helpful assistant."  # system prompt for the LLM
 )
 def process_with_llm(input_text: str) -> str:
@@ -52,7 +52,7 @@ class TextAnalysis(ai_sdk.BaseModel):
 
 @task.llm(
     model="gpt-4o-mini",
-    result_type=TextAnalysis,
+    output_type=TextAnalysis,
     system_prompt="Analyze the provided text."
 )
 def analyze_text(text: str) -> TextAnalysis:
@@ -134,7 +134,7 @@ You can use Airflow's built-in error handling features with these tasks:
 ```python
 @task.llm(
     model="gpt-4o-mini",
-    result_type=str,
+    output_type=str,
     system_prompt="Answer the question.",
     retries=3,  # retry 3 times if the task fails
     retry_delay=pendulum.duration(seconds=30),  # wait 30 seconds between retries

--- a/examples/dags/email_generation.py
+++ b/examples/dags/email_generation.py
@@ -62,7 +62,7 @@ class Email(ai_sdk.BaseModel):
 
 @task.llm(
     model="o3-mini",
-    result_type=Email,
+    output_type=Email,
     system_prompt="""
     You are a sales agent who is responsible for generating personalized email messages for prospects for Astro,
     the best managed Airflow service on the market. Given the audience is technical, you should focus on the

--- a/examples/dags/example_dag.py
+++ b/examples/dags/example_dag.py
@@ -1,0 +1,18 @@
+from airflow.decorators import dag, task
+
+
+@task.llm(
+    model="gpt-4o-mini",
+    system_prompt="Do some robot stuff",
+    output_type=str
+)
+def do_stuff() -> str:
+    return "do stuff"
+
+
+@dag
+def example_dag():
+    do_stuff()
+
+
+example_dag()

--- a/examples/dags/example_dag.py
+++ b/examples/dags/example_dag.py
@@ -1,11 +1,7 @@
 from airflow.decorators import dag, task
 
 
-@task.llm(
-    model="gpt-4o-mini",
-    system_prompt="Do some robot stuff",
-    output_type=str
-)
+@task.llm(model="gpt-4o-mini", system_prompt="Do some robot stuff", output_type=str)
 def do_stuff() -> str:
     return "do stuff"
 

--- a/examples/dags/product_feedback_summarization.py
+++ b/examples/dags/product_feedback_summarization.py
@@ -38,7 +38,7 @@ class ProductFeedbackSummary(ai_sdk.BaseModel):
     feature_requests: list[str]
 
 
-@task.llm(model="gpt-4o-mini", result_type=ProductFeedbackSummary, system_prompt="Extract the summary, sentiment, and feature requests from the product feedback.",)
+@task.llm(model="gpt-4o-mini", output_type=ProductFeedbackSummary, system_prompt="Extract the summary, sentiment, and feature requests from the product feedback.",)
 def summarize_product_feedback(feedback: str | None = None) -> ProductFeedbackSummary:
     """
     This task summarizes the product feedback. You can add logic here to transform the input

--- a/examples/dags/sentiment_classification.py
+++ b/examples/dags/sentiment_classification.py
@@ -6,7 +6,7 @@ from airflow.models.dagrun import DagRun
 
 @task.llm(
     model="gpt-4o-mini",
-    result_type=Literal["positive", "negative", "neutral"],
+    output_type=Literal["positive", "negative", "neutral"],
     system_prompt="Classify the sentiment of the given text.",
 )
 def process_with_llm(dag_run: DagRun) -> str:

--- a/tests/operators/test_llm.py
+++ b/tests/operators/test_llm.py
@@ -141,7 +141,7 @@ def test_init_with_model_object(base_config, patched_agent_class, patched_super_
     assert "python_callable" in kwargs
 
 
-def test_deprecated_call():
+def test_deprecated_call(base_config, patched_agent_class, patched_super_init, mock_agent):
     """
     Check for a deprecation warning from result_type.
     TODO remove test after removing support for result_type in airflow-ai-sdk 1.0.0.
@@ -170,7 +170,9 @@ def test_deprecated_call():
         )
 
 
-def test_no_deprecation_calls(recwarn: WarningsRecorder):
+def test_no_deprecation_calls(
+    recwarn: WarningsRecorder, base_config, patched_agent_class, patched_super_init, mock_agent
+):
     """We expect no deprecation warnings using these arguments."""
     LLMDecoratedOperator(
         task_id="test",

--- a/tests/operators/test_llm.py
+++ b/tests/operators/test_llm.py
@@ -5,6 +5,7 @@ Tests for the LLMDecoratedOperator class.
 from unittest.mock import MagicMock, patch
 
 import pytest
+from _pytest.recwarn import WarningsRecorder
 from pydantic import BaseModel
 from pydantic_ai.models import Model
 
@@ -43,8 +44,8 @@ def patched_super_init():
         yield mock_super_init
 
 
-def test_init_with_default_result_type(base_config, patched_agent_class, patched_super_init, mock_agent):
-    """Test initialization with default result type (str)."""
+def test_init_with_default_output_type(base_config, patched_agent_class, patched_super_init, mock_agent):
+    """Test initialization with default output type (str)."""
     # Create the operator
     operator = LLMDecoratedOperator(
         model=base_config["model"],
@@ -59,7 +60,7 @@ def test_init_with_default_result_type(base_config, patched_agent_class, patched
     patched_agent_class.assert_called_once_with(
         model=base_config["model"],
         system_prompt=base_config["system_prompt"],
-        result_type=str,
+        output_type=str,
     )
 
     # Verify that AgentDecoratedOperator.__init__ was called with the mock agent
@@ -72,8 +73,9 @@ def test_init_with_default_result_type(base_config, patched_agent_class, patched
     assert "python_callable" in kwargs
 
 
-def test_init_with_custom_result_type(base_config, patched_agent_class, patched_super_init, mock_agent):
-    """Test initialization with custom result type."""
+def test_init_with_custom_output_type(base_config, patched_agent_class, patched_super_init, mock_agent):
+    """Test initialization with custom output type."""
+
     # Create a test model
     class TestModel(BaseModel):
         field1: str
@@ -83,7 +85,7 @@ def test_init_with_custom_result_type(base_config, patched_agent_class, patched_
     operator = LLMDecoratedOperator(
         model=base_config["model"],
         system_prompt=base_config["system_prompt"],
-        result_type=TestModel,
+        output_type=TestModel,
         task_id="test_task",
         op_args=base_config["op_args"],
         op_kwargs=base_config["op_kwargs"],
@@ -94,7 +96,7 @@ def test_init_with_custom_result_type(base_config, patched_agent_class, patched_
     patched_agent_class.assert_called_once_with(
         model=base_config["model"],
         system_prompt=base_config["system_prompt"],
-        result_type=TestModel,
+        output_type=TestModel,
     )
 
     # Verify that AgentDecoratedOperator.__init__ was called with the mock agent
@@ -126,7 +128,7 @@ def test_init_with_model_object(base_config, patched_agent_class, patched_super_
     patched_agent_class.assert_called_once_with(
         model=mock_model,
         system_prompt=base_config["system_prompt"],
-        result_type=str,
+        output_type=str,
     )
 
     # Verify that AgentDecoratedOperator.__init__ was called with the mock agent
@@ -137,3 +139,46 @@ def test_init_with_model_object(base_config, patched_agent_class, patched_super_
     assert "op_args" in kwargs
     assert "op_kwargs" in kwargs
     assert "python_callable" in kwargs
+
+
+def test_deprecated_call():
+    """
+    Check for a deprecation warning from result_type.
+    TODO remove test after removing support for result_type in airflow-ai-sdk 1.0.0.
+    """
+    with pytest.deprecated_call():
+        LLMDecoratedOperator(
+            task_id="test",
+            system_prompt="Test me",
+            model="gpt-4",
+            op_args=[],
+            op_kwargs={},
+            python_callable=lambda: "test",
+            result_type=str,
+        )
+
+    with pytest.raises(ValueError):
+        LLMDecoratedOperator(
+            task_id="test",
+            system_prompt="Test me",
+            model="gpt-4",
+            op_args=[],
+            op_kwargs={},
+            python_callable=lambda: "test",
+            result_type=str,
+            output_type=str,
+        )
+
+
+def test_no_deprecation_calls(recwarn: WarningsRecorder):
+    """We expect no deprecation warnings using these arguments."""
+    LLMDecoratedOperator(
+        task_id="test",
+        system_prompt="Test me",
+        model="gpt-4",
+        op_args=[],
+        op_kwargs={},
+        python_callable=lambda: "test",
+        output_type=str,
+    )
+    assert len(recwarn) == 0

--- a/tests/operators/test_llm_branch.py
+++ b/tests/operators/test_llm_branch.py
@@ -131,7 +131,7 @@ def test_execute_with_enum_result(base_config, mock_context, mock_agent):
                     # Call execute
                     result = operator.execute(mock_context)
 
-                    # Verify a new Agent was created with the correct enum result_type
+                    # Verify a new Agent was created with the correct enum output_type
                     assert mock_agent_class.call_count == 2  # Once in __init__ and once in execute
 
                     # Verify that super().execute was called


### PR DESCRIPTION
In pydantic-ai, the argument `result_type` has been deprecated since 0.1.0, and was removed in [0.6.0](https://github.com/pydantic/pydantic-ai/releases/tag/v0.6.0), released on August 6th. It has been replaced by an argument `output_type`. This broke airflow-ai-sdk on August 6th because we set no upper boundary for pydantic-ai.

The fix without this PR is to pin `pydantic-ai-slim<0.6.0` in your requirements.txt.

This PR aims to support both `result_type` and `output_type` as valid arguments to avoid breaking changes in airflow-ai-sdk, until airflow-ai-sdk==1.0.0 where we can break things and remove `result_type`. When a user configures `result_type`, it will now raise a DeprecationWarning:

```
DeprecationWarning: Argument `result_type` is deprecated and will be removed in version 1.0.0. Use `output_type` instead.
```

Note: I didn't change the lower boundary for `pydantic-ai-slim` (`>=0.4.0`) because pydantic-ai introduced `output_type` + has been raising deprecation warnings for `result_type` since [0.1.0](https://github.com/pydantic/pydantic-ai/releases/tag/v0.1.0), so I didn't feel a change here was necessary.