### PR TITLE
Add a 7-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

Introduces a **7-day Dependabot cooldown** (`cooldown: default-days: 7`) on the `uv` ecosystem, matching the policy already used in `astronomer/dag-factory` and `astronomer/astronomer-cosmos`.

Today Dependabot opens dependency-bump PRs here immediately on release. A cooldown makes routine bumps wait 7 days after a version is published before a PR opens, giving the community time to surface supply-chain issues (yanked releases, regressions, compromised packages). **Security updates are exempt** and keep opening immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
