### PR TITLE
Deprecate airflow-ai-sdk in favor of apache-airflow-providers-common-ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # airflow-ai-sdk
 
+## ⚠️ Discontinuation of project
+
+> This project is no longer actively maintained by Astronomer. Development has been paused and we are
+> not accepting new contributions, bug fixes or releases.
+>
+> **We recommend migrating to [`apache-airflow-providers-common-ai`](https://pypi.org/project/apache-airflow-providers-common-ai/)**, the official Apache Airflow provider for AI and LLM workflows, which is where new development now happens. See the [migration guide](https://www.astronomer.io/blog/migrating-from-airflow-ai-sdk-to-apache-airflow-s-common-ai-provider/) for step-by-step instructions.
+>
+> The code is still here for you to explore, fork and adapt under the terms of its license. Please note
+> that it may not work with the latest dependencies or platforms, and it could contain security
+> vulnerabilities. Astronomer can't offer guarantees or warranties for its use.
+>
+> If you're interested in adopting or stewarding this project, we'd be happy to chat, reach us at
+> oss@astronomer.io. Thanks for being part of the open-source journey and helping keep great ideas
+> alive!
+
+---
+
 A Python SDK for working with LLMs from [Apache Airflow](https://github.com/apache/airflow). It allows users to call LLMs and orchestrate agent calls directly within their Airflow pipelines using decorator-based tasks.
 
 We find it's often helpful to rely on mature orchestration tooling like Airflow for instrumenting LLM workflows and agents in production, as these LLM workflows follow the same form factor as more traditional workflows like ETL pipelines, operational processes, and ML workflows.

--- a/airflow_ai_sdk/__init__.py
+++ b/airflow_ai_sdk/__init__.py
@@ -11,7 +11,7 @@ This package provides an SDK for building LLM workflows and agents using Apache 
 import warnings
 from typing import Any
 
-__version__ = "0.1.8a1"
+__version__ = "0.1.8"
 
 warnings.warn(
     "airflow-ai-sdk is deprecated and no longer maintained. Please migrate to "

--- a/airflow_ai_sdk/__init__.py
+++ b/airflow_ai_sdk/__init__.py
@@ -11,7 +11,7 @@ This package provides an SDK for building LLM workflows and agents using Apache 
 import warnings
 from typing import Any
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 
 warnings.warn(
     "airflow-ai-sdk is deprecated and no longer maintained. Please migrate to "

--- a/airflow_ai_sdk/__init__.py
+++ b/airflow_ai_sdk/__init__.py
@@ -11,7 +11,7 @@ This package provides an SDK for building LLM workflows and agents using Apache 
 import warnings
 from typing import Any
 
-__version__ = "0.1.8"
+__version__ = "0.1.8a1"
 
 warnings.warn(
     "airflow-ai-sdk is deprecated and no longer maintained. Please migrate to "

--- a/airflow_ai_sdk/__init__.py
+++ b/airflow_ai_sdk/__init__.py
@@ -1,10 +1,26 @@
 """
 This package provides an SDK for building LLM workflows and agents using Apache Airflow.
+
+.. deprecated::
+    airflow-ai-sdk is no longer actively maintained. Please migrate to
+    ``apache-airflow-providers-common-ai``, the official Apache Airflow provider for AI
+    and LLM workflows. See the migration guide:
+    https://www.astronomer.io/blog/migrating-from-airflow-ai-sdk-to-apache-airflow-s-common-ai-provider/
 """
 
+import warnings
 from typing import Any
 
 __version__ = "0.1.7"
+
+warnings.warn(
+    "airflow-ai-sdk is deprecated and no longer maintained. Please migrate to "
+    "'apache-airflow-providers-common-ai', the official Apache Airflow provider for AI "
+    "and LLM workflows. Migration guide: "
+    "https://www.astronomer.io/blog/migrating-from-airflow-ai-sdk-to-apache-airflow-s-common-ai-provider/",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 from airflow_ai_sdk.decorators.agent import agent
 from airflow_ai_sdk.decorators.branch import llm_branch

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,16 @@
 # Airflow AI SDK Documentation
 
+## ⚠️ Discontinuation of project
+
+> This project is no longer actively maintained by Astronomer. Development has been paused and we are
+> not accepting new contributions, bug fixes or releases.
+>
+> **We recommend migrating to [`apache-airflow-providers-common-ai`](https://pypi.org/project/apache-airflow-providers-common-ai/)**, the official Apache Airflow provider for AI and LLM workflows. See the [migration guide](https://www.astronomer.io/blog/migrating-from-airflow-ai-sdk-to-apache-airflow-s-common-ai-provider/) for step-by-step instructions.
+>
+> If you're interested in adopting or stewarding this project, reach us at oss@astronomer.io.
+
+---
+
 Welcome to the Airflow AI SDK documentation. This SDK allows you to work with LLMs from Apache Airflow, based on [Pydantic AI](https://ai.pydantic.dev).
 
 ## Table of Contents

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,16 @@
 # airflow-ai-sdk
 
+## ⚠️ Discontinuation of project
+
+> This project is no longer actively maintained by Astronomer. Development has been paused and we are
+> not accepting new contributions, bug fixes or releases.
+>
+> **We recommend migrating to [`apache-airflow-providers-common-ai`](https://pypi.org/project/apache-airflow-providers-common-ai/)**, the official Apache Airflow provider for AI and LLM workflows. See the [migration guide](https://www.astronomer.io/blog/migrating-from-airflow-ai-sdk-to-apache-airflow-s-common-ai-provider/) for step-by-step instructions.
+>
+> If you're interested in adopting or stewarding this project, reach us at oss@astronomer.io.
+
+---
+
 This SDK allows you to work with LLMs from Apache Airflow, based on [Pydantic AI](https://ai.pydantic.dev). It enables calling LLMs and orchestrating agent calls directly within Airflow pipelines using decorator-based tasks.
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = "hatchling.build"
 [project]
 name = "airflow-ai-sdk"
 dynamic = ["version"]
-description = "SDK for building LLM workflows and agents using Apache Airflow"
+description = "[DEPRECATED - use apache-airflow-providers-common-ai] SDK for building LLM workflows and agents using Apache Airflow"
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 7 - Inactive",
     "Framework :: Apache Airflow",
     "Framework :: Apache Airflow :: Provider",
     "Intended Audience :: Developers",


### PR DESCRIPTION
## Summary

Deprecate this project and direct users to [`apache-airflow-providers-common-ai`](https://pypi.org/project/apache-airflow-providers-common-ai/), the official Apache Airflow provider for AI and LLM workflows. Follows the same pattern as [apache-airflow-providers-transfers](https://github.com/astronomer/apache-airflow-providers-transfers).

## Changes

- **README.md** / **docs/index.md**: Add a `⚠️ Discontinuation of project` banner with a link to the [migration guide](https://www.astronomer.io/blog/migrating-from-airflow-ai-sdk-to-apache-airflow-s-common-ai-provider/).
- **pyproject.toml**: Set classifier to `Development Status :: 7 - Inactive` and flag the package description as deprecated (surfaces on PyPI).
- **airflow_ai_sdk/__init__.py**: Emit a `DeprecationWarning` on import so installed users get the migration message at runtime.
- **airflow_ai_sdk/__init__.py**: Bump version

## Follow-ups (outside this PR)

- Publish a release so the PyPI page reflects the deprecated metadata.
- Archive the GitHub repo.
- Create the deprecation tracking issue from [oss-integrations-private#187](https://github.com/astronomer/oss-integrations-private/issues/187).

Ref: BOSS-376

🤖 Generated with [Claude Code](https://claude.com/claude-code)